### PR TITLE
Fixed bug when generating products for an API

### DIFF
--- a/APIManagementTemplate.Test/TemplatesGeneratorTests.cs
+++ b/APIManagementTemplate.Test/TemplatesGeneratorTests.cs
@@ -253,7 +253,8 @@ namespace APIManagementTemplate.Test
         {
             var template = _generatedTemplates.Single(x => x.FileName == EchoFilename);
 
-            var productApi = template.Content.SelectToken("$.resources[?(@.type=='Microsoft.ApiManagement/service/products/apis')]");
+            var productApis = template.Content.SelectTokens("$.resources[?(@.type=='Microsoft.ApiManagement/service/products/apis')]");
+            var productApi = productApis.FirstOrDefault();
             Assert.IsNotNull(productApi);
 
             Assert.AreEqual("[concat(parameters('service_PreDemoTest_name'), '/', 'starter', '/', 'echo-api')]", productApi.Value<string>("name"));
@@ -263,6 +264,17 @@ namespace APIManagementTemplate.Test
 
             Assert.AreEqual("[resourceId('Microsoft.ApiManagement/service/apis', parameters('service_PreDemoTest_name'),'echo-api')]", 
                 dependsOn.First());
+        }
+
+        [TestMethod]
+        public void TestResultContainsAPIFor_EchoV1With2ProductAPI()
+        {
+            var template = _generatedTemplates.Single(x => x.FileName == EchoFilename);
+
+            var productApis = template.Content.SelectTokens("$.resources[?(@.type=='Microsoft.ApiManagement/service/products/apis')]");
+            Assert.AreEqual(2, productApis.Count());
+            Assert.IsTrue(productApis.Any(x => x.Value<string>("name") == "[concat(parameters('service_PreDemoTest_name'), '/', 'unlimited', '/', 'echo-api')]"));
+            Assert.IsTrue(productApis.Any(x => x.Value<string>("name") == "[concat(parameters('service_PreDemoTest_name'), '/', 'starter', '/', 'echo-api')]"));
         }
 
         [TestMethod]

--- a/APIManagementTemplate/TemplatesGenerator.cs
+++ b/APIManagementTemplate/TemplatesGenerator.cs
@@ -598,9 +598,9 @@ namespace APIManagementTemplate
             string apiName = GetParameterPart(api, "name", -2);
             if (apiName.StartsWith("/"))
                 apiName = apiName.Substring(1, apiName.Length - 1);
-            var productApi = parsedTemplate.SelectTokens($"$..resources[?(@.type=='{ProductAPIResourceType}')]")
-                .FirstOrDefault(p => GetParameterPart(p, "name", -2) == apiName);
-            if (productApi != null)
+            var productApis = parsedTemplate.SelectTokens($"$..resources[?(@.type=='{ProductAPIResourceType}')]")
+                .Where(p => GetParameterPart(p, "name", -2) == apiName);
+            foreach (JToken productApi in productApis)
             {
                 var dependsOn = productApi.Value<JArray>("") ?? new JArray();
                 var serviceName = GetParameterPart(api, "name", -4);


### PR DESCRIPTION
Lets assume we have one API (echo) that is included in two products (started and unlimited).

Before Write-APIManagementTemplates would only generate the first product the API was included in (starter).
Now this is fixed and the echo API is included in both the starter and unlimited products.