### PR TITLE
Fixed issues with duplicate resources in arm templates after merge and duplicate api diagnostics

### DIFF
--- a/APIManagementTemplate.Test/APIManagementTemplate.Test.csproj
+++ b/APIManagementTemplate.Test/APIManagementTemplate.Test.csproj
@@ -35,11 +35,19 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FluentAssertions, Version=5.6.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.5.6.0\lib\net45\FluentAssertions.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -60,6 +68,7 @@
     <Compile Include="DeploymentTemplateTests.cs" />
     <Compile Include="FunctionAppMixedWithLogicAppTests.cs" />
     <Compile Include="TemplateMergerTests.cs" />
+    <Compile Include="TemplatesGeneratorTestsWithoutApiVersionSetId.cs" />
     <Compile Include="TemplatesGeneratorTestsWithListApiInProduct.cs" />
     <Compile Include="TemplatesGeneratorTestsWithSwagger.cs" />
     <Compile Include="TemplatesGeneratorTestsWithSeparatePolicyFileAsFalse.cs" />
@@ -86,7 +95,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <EmbeddedResource Include="Samples\MaloInstance-Preview-Export.json" />
     <EmbeddedResource Include="Samples\malo-apiminstance.json" />
     <EmbeddedResource Include="Samples\Policies\AzureResource-LogicApp-unmodified.json" />

--- a/APIManagementTemplate.Test/TemplateMergerTests.cs
+++ b/APIManagementTemplate.Test/TemplateMergerTests.cs
@@ -119,18 +119,18 @@ namespace APIManagementTemplate.Test
         public void TestComplexArrayMergeStringValues1()
         {
             AssertMerge(
-                new { dependsOn = new object[] { "a", "b" } },
+                new { dependsOn = new object[] { "a", "shouldBeSame" } },
                 new { dependsOn = new object[] { "c" } },
-                new { dependsOn = new object[] { "a", "b", "c" } });
+                new { dependsOn = new object[] { "a", "shouldBeSame", "c" } });
         }
 
         [TestMethod]
         public void TestComplexArrayMergeStringValues2()
         {
             AssertMerge(
-                new { dependsOn = new object[] { "a", "b" } },
+                new { dependsOn = new object[] { "a", "shouldBeSame" } },
                 new { dependsOn = new object[] { "a", "c" } },
-                new { dependsOn = new object[] { "a", "b", "c" } });
+                new { dependsOn = new object[] { "a", "shouldBeSame", "c" } });
         }
 
         [TestMethod]
@@ -169,12 +169,44 @@ namespace APIManagementTemplate.Test
                 new { resources = new object[] { new { name = "1", type = "1", a = 1 }, new { name = "1", type = "2", a = 2 } } });
         }
 
+        [TestMethod]
+        public void TestSameNameButWithSpacesBetweenNames()
+        {
+            TestSameName(
+                "[concat(parameters('apimServiceName'),'/','c341bf18-54fb-4685-ad4b-3e49b4a847c2')]", 
+                "[concat(parameters('apimServiceName'), '/', 'c341bf18-54fb-4685-ad4b-3e49b4a847c2')]");
+        }
 
-        private static void AssertMerge(object oldObject, object newObject, object expected)
+        [TestMethod]
+        public void TestSameNameButWithMoreSpacesBetweenNames()
+        {
+            TestSameName(
+                "[concat(parameters('apimServiceName'),'/','c341bf18-54fb-4685-ad4b-3e49b4a847c2')]", 
+                "[concat( parameters('apimServiceName'), '/' , 'c341bf18-54fb-4685-ad4b-3e49b4a847c2' )]");
+        }
+
+        [TestMethod]
+        public void TestSameNameButWithSpacesInName()
+        {
+            TestSameName(
+                "[concat(parameters('apimServiceName'),'/','c341bf18-54fb-4685-ad4b-3e49b4a847c2')]", 
+                "[concat( parameters('apimServiceName '), '/' , 'c341bf18-54fb-4685-ad4b-3e49b4a847c2' )]");
+        }
+
+        private static void TestSameName(string name1, string name2, bool shouldBeSame=true)
+        {
+            AssertMerge(
+                new {resources = new object[] {new {name = name1, type = "1", a = 1}}},
+                new {resources = new object[] {new {name = name2, type = "1", a = 2}}},
+                new {resources = new object[] {new {name = name2, type = "1", a = 2}}}, shouldBeSame);
+        }
+
+
+        private static void AssertMerge(object oldObject, object newObject, object expected, bool shouldBeSame=true)
         {
             JObject result = TemplateMerger.Merge(JObject.FromObject(oldObject), JObject.FromObject(newObject));
 
-            Assert.IsTrue(JObject.EqualityComparer.Equals(JObject.FromObject(expected), result));
+            Assert.AreEqual(shouldBeSame, JObject.EqualityComparer.Equals(JObject.FromObject(expected), result));
         }
     }
 }

--- a/APIManagementTemplate.Test/TemplateMergerTests.cs
+++ b/APIManagementTemplate.Test/TemplateMergerTests.cs
@@ -119,18 +119,18 @@ namespace APIManagementTemplate.Test
         public void TestComplexArrayMergeStringValues1()
         {
             AssertMerge(
-                new { dependsOn = new object[] { "a", "shouldBeSame" } },
+                new { dependsOn = new object[] { "a", "b" } },
                 new { dependsOn = new object[] { "c" } },
-                new { dependsOn = new object[] { "a", "shouldBeSame", "c" } });
+                new { dependsOn = new object[] { "a", "b", "c" } });
         }
 
         [TestMethod]
         public void TestComplexArrayMergeStringValues2()
         {
             AssertMerge(
-                new { dependsOn = new object[] { "a", "shouldBeSame" } },
+                new { dependsOn = new object[] { "a", "b" } },
                 new { dependsOn = new object[] { "a", "c" } },
-                new { dependsOn = new object[] { "a", "shouldBeSame", "c" } });
+                new { dependsOn = new object[] { "a", "b", "c" } });
         }
 
         [TestMethod]

--- a/APIManagementTemplate.Test/TemplatesGeneratorTestsWithoutApiVersionSetId.cs
+++ b/APIManagementTemplate.Test/TemplatesGeneratorTestsWithoutApiVersionSetId.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+
+namespace APIManagementTemplate.Test
+{
+    [TestClass]
+    public class TemplatesGeneratorTestsWithoutApiVersionSetId
+    {
+        private IResourceCollector _collector;
+        private JObject _template = null;
+        private IList<GeneratedTemplate> _generatedTemplates;
+
+        [TestInitialize()]
+        public void Initialize()
+        {
+            this._collector = new MockResourceCollector("WithoutApiVersionSetId");
+            _generatedTemplates = GetGeneratedTemplates().GetAwaiter().GetResult();
+        }
+
+        private async Task<JObject> GetTemplate(bool exportProducts = false, bool parametrizePropertiesOnly = true,
+            bool replaceSetBackendServiceBaseUrlAsProperty = false, bool fixedServiceNameParameter = false,
+            bool createApplicationInsightsInstance = false, bool exportSwaggerDefinition = false)
+        {
+            if (this._template != null)
+                return this._template;
+            var generator = new TemplateGenerator("ibizmalo", "c107df29-a4af-4bc9-a733-f88f0eaa4296", "PreDemoTest",
+                "maloapimtestclean", false, exportProducts, true, parametrizePropertiesOnly, this._collector,
+                replaceSetBackendServiceBaseUrlAsProperty, fixedServiceNameParameter,
+                createApplicationInsightsInstance, exportSwaggerDefinition: exportSwaggerDefinition);
+            this._template = await generator.GenerateTemplate();
+            return this._template;
+        }
+
+        [TestMethod]
+        public async Task TestApiTemplateShouldNotHaveSameResourcesAsApiSwaggerTemplate()
+        {
+            var names = GetApiResourceNames(_generatedTemplates, Filename.TFSTemplate);
+            var swaggerNames = GetApiResourceNames(_generatedTemplates, Filename.TFSSwaggerTemplate);
+            var sameNames = names.Intersect(swaggerNames);
+            sameNames.Should().BeEmpty();
+        }
+
+        private static IEnumerable<string> GetApiResourceNames(IList<GeneratedTemplate> generatedTemplates, Filename template)
+        {
+            var apiTemplate = generatedTemplates.With(template).WithDirectResource(ResourceType.Api);
+            var resources = apiTemplate.ValueWithType<JArray>(Arm.Resources);
+            Assert.IsNotNull(resources);
+            return resources.Select(x => $"{x.Value(Arm.Type)}_{x.Value(Arm.Name)}");
+        }
+
+        private async Task<IList<GeneratedTemplate>> GetGeneratedTemplates()
+        {
+            var template = await GetTemplate(exportProducts: true, fixedServiceNameParameter: true,
+                createApplicationInsightsInstance: true, exportSwaggerDefinition: true,
+                replaceSetBackendServiceBaseUrlAsProperty: true);
+
+            var templatesGenerator = new TemplatesGenerator();
+            var generatedTemplates = templatesGenerator.Generate(template.ToString(), true, true,
+                true, true, false, separateSwaggerFile: true);
+            return generatedTemplates;
+        }
+    }
+}

--- a/APIManagementTemplate.Test/TemplatesGeneratorTestsWithoutApiVersionSetId.cs
+++ b/APIManagementTemplate.Test/TemplatesGeneratorTestsWithoutApiVersionSetId.cs
@@ -44,6 +44,14 @@ namespace APIManagementTemplate.Test
             sameNames.Should().BeEmpty();
         }
 
+        [TestMethod]
+        public async Task TestApiShouldContainApiDiagnostic()
+        {
+            var diagnostic = _generatedTemplates.With(Filename.TFSTemplate).WithDirectResource(ResourceType.Api)
+                .WithDirectResource(ResourceType.ApiDiagnostic);
+            diagnostic.Should().NotBeNull();
+        }
+
         private static IEnumerable<string> GetApiResourceNames(IList<GeneratedTemplate> generatedTemplates, Filename template)
         {
             var apiTemplate = generatedTemplates.With(template).WithDirectResource(ResourceType.Api);

--- a/APIManagementTemplate.Test/TestExtensions.cs
+++ b/APIManagementTemplate.Test/TestExtensions.cs
@@ -105,7 +105,9 @@ namespace APIManagementTemplate.Test
         [Description("copy")]
         Copy,
         [Description("count")]
-        Count
+        Count,
+        [Description("resources")]
+        Resources
     }
 
     public enum Filename
@@ -137,7 +139,11 @@ namespace APIManagementTemplate.Test
         [Description("master.template.json")]
         MasterTemplate,
         [Description("api-Echo-API.create-resource.policy.xml")]
-        EchoCreateResourcePolicy
+        EchoCreateResourcePolicy,
+        [Description("api-TFS.template.json")]
+        TFSTemplate,
+        [Description("api-TFS.swagger.template.json")]
+        TFSSwaggerTemplate,
     }
 
     public enum ResourceType

--- a/APIManagementTemplate.Test/TestExtensions.cs
+++ b/APIManagementTemplate.Test/TestExtensions.cs
@@ -183,7 +183,9 @@ namespace APIManagementTemplate.Test
         [Description("Microsoft.Insights/components")]
         ApplicationInsights,
         [Description("Microsoft.ApiManagement/service/diagnostics")]
-        Diagnostics,
+        Diagnostic,
+        [Description("Microsoft.ApiManagement/service/apis/diagnostics")]
+        ApiDiagnostic,
         [Description("Microsoft.ApiManagement/service/products/apis")]
         ProductApi,
         [Description("Microsoft.ApiManagement/service/products")]

--- a/APIManagementTemplate.Test/WithoutApiVersionSetIdTests.cs
+++ b/APIManagementTemplate.Test/WithoutApiVersionSetIdTests.cs
@@ -524,7 +524,7 @@ namespace APIManagementTemplate.Test
         [TestMethod]
         public void TestServiceContainsDiagnosticsForAzureMonitor()
         {
-            var diagnostic = GetSubResourceFromTemplate(ResourceType.Service, ResourceType.Diagnostics).Skip(1)
+            var diagnostic = GetSubResourceFromTemplate(ResourceType.Service, ResourceType.Diagnostic).Skip(1)
                 .SingleOrDefault();
             Assert.IsNotNull(diagnostic);
             Assert.AreEqual($"[concat(parameters('service_ibizmalo_name'), '/', 'azuremonitor')]",
@@ -539,7 +539,7 @@ namespace APIManagementTemplate.Test
         private void AssertDiagnostic(bool createApplicationInsightsInstance, bool parametrizePropertiesOnly,
             string name, string loggerName)
         {
-            var diagnostics = GetSubResourceFromTemplate(ResourceType.Service, ResourceType.Diagnostics,
+            var diagnostics = GetSubResourceFromTemplate(ResourceType.Service, ResourceType.Diagnostic,
                     createApplicationInsightsInstance, parametrizePropertiesOnly)
                 .FirstOrDefault();
             Assert.IsNotNull(diagnostics);

--- a/APIManagementTemplate.Test/packages.config
+++ b/APIManagementTemplate.Test/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="FluentAssertions" version="5.6.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net452" />
 </packages>

--- a/APIManagementTemplate/TemplateMerger.cs
+++ b/APIManagementTemplate/TemplateMerger.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Remoting.Metadata.W3cXsd2001;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 
 namespace APIManagementTemplate
@@ -83,7 +86,18 @@ namespace APIManagementTemplate
         {
             if (properties.Any(p => x.Value<string>(p) == null || y.Value<string>(p) == null))
                 return false;
-            return properties.All(p => x.Value<string>(p) == y.Value<string>(p));
+            return properties.All(p => Compare(x, y, p));
+        }
+
+        private static bool Compare(JToken x, JToken y, string property)
+        {
+            var xValue = x.Value<string>(property);
+            var yValue = y.Value<string>(property);
+            if (property == "name")
+            {
+                return xValue.Replace(" ", String.Empty) == yValue.Replace(" ", String.Empty);
+            }
+            return xValue == yValue;
         }
     }
 


### PR DESCRIPTION
# Issue 1
Recently spaces were added into the names of many resources.
From
"[concat(parameters('apimServiceName'),'/','c341bf18-54fb-4685-ad4b-3e49b4a847c2')]"
to
"[concat(parameters('apimServiceName'), '/', 'c341bf18-54fb-4685-ad4b-3e49b4a847c2')]"
When deploying it does not matter at all.
But the template merger function did a string comparison of the old and new name and did not consider the names equal. The result was that a new resource was created in the template even though a resource with (almost) the same name existed there already.
The fix is to be more loose when checking if the resource already exists in the existing arm template (when merging templates).

# Issue 2
The API Diagnostics resources was created as a resource for the API in both api\*template.json and api\*.swagger.template.json when using SeparateSwaggerFile=true. 
The fix was to make sure that it was only added to api\*.template.json

# New unit test type
I also created a new type of unit test file TemplatesGeneratorTestsWithoutApiVersionSetId which first generates the big template (similar to Get-APIManagementTemplate) and then based on that generates the many templates (similar to Write-APIManagementTemplates). I think this is better compared to the old way of writing tests where the source is an generated template stored in a text file (SamplesTemplate\template.json) which is probably not up to date.

# Fluent assertions
I also added nuget package Fluent Assertions https://fluentassertions.com/ that allows you to write assertions that are easier to read and produces better messages when failing.