### PR TITLE
Add option chainDependencies to avoid concurrency conflicts

### DIFF
--- a/APIManagementTemplate/GeneratorCmdlet.cs
+++ b/APIManagementTemplate/GeneratorCmdlet.cs
@@ -80,6 +80,9 @@ namespace APIManagementTemplate
         [Parameter(Mandatory = false, HelpMessage = "SeparatePolicyOutputFolder.")]
         public string SeparatePolicyOutputFolder = "";
 
+        [Parameter(Mandatory = false, HelpMessage = "Set to 'true' if you get the error 'Operation on the API is in progress'. This option chains the product apis in order to reduce parallelism.")]
+        public bool ChainDependencies = false;
+
         protected override void ProcessRecord()
         {
             AzureResourceCollector resourceCollector = new AzureResourceCollector();
@@ -103,7 +106,7 @@ namespace APIManagementTemplate
 
             try
             {
-                TemplateGenerator generator = new TemplateGenerator(APIManagement, SubscriptionId, ResourceGroup, APIFilters, ExportGroups, ExportProducts, ExportPIManagementInstance, ParametrizePropertiesOnly, resourceCollector, ReplaceSetBackendServiceBaseUrlWithProperty, FixedServiceNameParameter, CreateApplicationInsightsInstance, ApiVersion, ParameterizeBackendFunctionKey, ExportSwaggerDefinition, ExportCertificates, ExportTags, SeparatePolicyOutputFolder);
+                TemplateGenerator generator = new TemplateGenerator(APIManagement, SubscriptionId, ResourceGroup, APIFilters, ExportGroups, ExportProducts, ExportPIManagementInstance, ParametrizePropertiesOnly, resourceCollector, ReplaceSetBackendServiceBaseUrlWithProperty, FixedServiceNameParameter, CreateApplicationInsightsInstance, ApiVersion, ParameterizeBackendFunctionKey, ExportSwaggerDefinition, ExportCertificates, ExportTags, SeparatePolicyOutputFolder, ChainDependencies);
                 JObject result = generator.GenerateTemplate().Result;
                 WriteObject(result.ToString());
             }

--- a/APIManagementTemplate/Models/DeploymentTemplate.cs
+++ b/APIManagementTemplate/Models/DeploymentTemplate.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -1079,8 +1079,6 @@ namespace APIManagementTemplate.Models
 
                 obj.properties["sampling"]["percentage"] = WrapParameterName(AddParameter($"diagnostic_{name}_samplingPercentage", "string", GetDefaultValue(restObject, "sampling", "percentage")));
 
-
-                obj.dependsOn.Add($"[resourceId('Microsoft.ApiManagement/service/apis', parameters('{GetServiceName(servicename)}'), {apiname})]");
                 //add when logger object is added
                 //obj.dependsOn.Add(loggerResource);
                 if (IsApplicationInsightsLogger(loggerObject))
@@ -1088,6 +1086,8 @@ namespace APIManagementTemplate.Models
                     obj.properties["enableHttpCorrelationHeaders"] = WrapParameterName(AddParameter($"diagnostic_{name}_enableHttpCorrelationHeaders", "bool", GetDefaultValue(resource, true, "enableHttpCorrelationHeaders")));
                 }
             }
+
+            obj.dependsOn.Add($"[resourceId('Microsoft.ApiManagement/service/apis', parameters('{GetServiceName(servicename)}'), {apiname})]");
             return JObject.FromObject(obj);
         }
 

--- a/APIManagementTemplate/TemplateGenerator.cs
+++ b/APIManagementTemplate/TemplateGenerator.cs
@@ -33,8 +33,9 @@ namespace APIManagementTemplate
         private readonly bool exportSwaggerDefinition;
         IResourceCollector resourceCollector;
         private string separatePolicyOutputFolder;
+        private bool chainDependencies;
 
-        public TemplateGenerator(string servicename, string subscriptionId, string resourceGroup, string apiFilters, bool exportGroups, bool exportProducts, bool exportPIManagementInstance, bool parametrizePropertiesOnly, IResourceCollector resourceCollector, bool replaceSetBackendServiceBaseUrlAsProperty = false, bool fixedServiceNameParameter = false, bool createApplicationInsightsInstance = false, string apiVersion = null, bool parameterizeBackendFunctionKey = false, bool exportSwaggerDefinition = false, bool exportCertificates = true, bool exportTags = false, string separatePolicyOutputFolder = "")
+        public TemplateGenerator(string servicename, string subscriptionId, string resourceGroup, string apiFilters, bool exportGroups, bool exportProducts, bool exportPIManagementInstance, bool parametrizePropertiesOnly, IResourceCollector resourceCollector, bool replaceSetBackendServiceBaseUrlAsProperty = false, bool fixedServiceNameParameter = false, bool createApplicationInsightsInstance = false, string apiVersion = null, bool parameterizeBackendFunctionKey = false, bool exportSwaggerDefinition = false, bool exportCertificates = true, bool exportTags = false, string separatePolicyOutputFolder = "", bool chainDependencies = false)
         {
             this.servicename = servicename;
             this.subscriptionId = subscriptionId;
@@ -54,6 +55,7 @@ namespace APIManagementTemplate
             this.parameterizeBackendFunctionKey = parameterizeBackendFunctionKey;
             this.exportSwaggerDefinition = exportSwaggerDefinition;
             this.separatePolicyOutputFolder = separatePolicyOutputFolder;
+            this.chainDependencies = chainDependencies;
         }
 
         private string GetAPIMResourceIDString()
@@ -63,7 +65,7 @@ namespace APIManagementTemplate
 
         public async Task<JObject> GenerateTemplate()
         {
-            DeploymentTemplate template = new DeploymentTemplate(this.parametrizePropertiesOnly, this.fixedServiceNameParameter, this.createApplicationInsightsInstance, this.parameterizeBackendFunctionKey, this.separatePolicyOutputFolder);
+            DeploymentTemplate template = new DeploymentTemplate(this.parametrizePropertiesOnly, this.fixedServiceNameParameter, this.createApplicationInsightsInstance, this.parameterizeBackendFunctionKey, this.separatePolicyOutputFolder, this.chainDependencies);
             if (exportPIManagementInstance)
             {
                 var apim = await resourceCollector.GetResource(GetAPIMResourceIDString());

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Example when user is connected to multitenants:
 | ClaimsDump | A dump of claims piped in from `armclient` - should not be manually set | false | |
 | ParameterizeBackendFunctionKey | Set to 'true' if you want the backend function key to be parameterized | false | false |
 | SeparatePolicyOutputFolder | Set to an output folder if you want to save the policies in a separate file. The output folder must be relative to the directory _artifactsLocation/_artifactsBlobPrefix. Parameters _artifactsLocation, _artifactsBlobPrefix and _artifactsSASToken are added to the template automatically. This parameter is useful when the policy size exceeds the 16KB limit and you do not want separate ARM templates for all objects. | false | |
+| ChainDependencies | Set to 'true' if you get the error "Operation on the API is in progress". This option chains the product apis in order to reduce parallelism | false | false |
   
 After extraction a parameters file can be created off the ARMTemplate.
 


### PR DESCRIPTION
Default behaviour is the current behaviour, so by default this option is switched off.
So use this option if you encounter concurrency conflicts. Fixes #85.

This PR also solves a dependency problem with the diagnostics template. Fixes #84.