### PR TITLE
Fix function key dependency bug

### DIFF
--- a/APIManagementTemplate.Test/WithoutApiVersionSetIdTests.cs
+++ b/APIManagementTemplate.Test/WithoutApiVersionSetIdTests.cs
@@ -24,25 +24,27 @@ namespace APIManagementTemplate.Test
 
         private JObject GetTemplate(bool exportProducts = false, bool parametrizePropertiesOnly = true,
             bool replaceSetBackendServiceBaseUrlAsProperty = false, bool fixedServiceNameParameter = false,
-            bool createApplicationInsightsInstance = false, bool exportSwaggerDefinition = false, bool exportGroups = false)
+            bool createApplicationInsightsInstance = false, bool exportSwaggerDefinition = false, bool exportGroups = false, 
+            bool parameterizeBackendFunctionKey = false)
         {
             if (this._template != null)
                 return this._template;
             var generator = new TemplateGenerator("ibizmalo", "c107df29-a4af-4bc9-a733-f88f0eaa4296", "PreDemoTest",
                 "maloapimtestclean", exportGroups, exportProducts, true, parametrizePropertiesOnly, this.collector,
                 replaceSetBackendServiceBaseUrlAsProperty, fixedServiceNameParameter,
-                createApplicationInsightsInstance, exportSwaggerDefinition: exportSwaggerDefinition);
+                createApplicationInsightsInstance, exportSwaggerDefinition: exportSwaggerDefinition, parameterizeBackendFunctionKey: parameterizeBackendFunctionKey);
             this._template = generator.GenerateTemplate().GetAwaiter().GetResult();
             return this._template;
         }
 
 
         private JToken GetResourceFromTemplate(ResourceType resourceType, bool createApplicationInsightsInstance = false,
-            bool parametrizePropertiesOnly = true, bool fixedServiceNameParameter = false, bool exportSwaggerDefinition = false, bool replaceSetBackendServiceBaseUrlAsProperty=false)
+            bool parametrizePropertiesOnly = true, bool fixedServiceNameParameter = false, bool exportSwaggerDefinition = false, bool replaceSetBackendServiceBaseUrlAsProperty=false, bool parameterizeBackendFunctionKey = false)
         {
             var template = GetTemplate(true, parametrizePropertiesOnly,
                 fixedServiceNameParameter: fixedServiceNameParameter,
-                createApplicationInsightsInstance: createApplicationInsightsInstance, exportSwaggerDefinition: exportSwaggerDefinition, replaceSetBackendServiceBaseUrlAsProperty:replaceSetBackendServiceBaseUrlAsProperty);
+                createApplicationInsightsInstance: createApplicationInsightsInstance, exportSwaggerDefinition: exportSwaggerDefinition, replaceSetBackendServiceBaseUrlAsProperty:replaceSetBackendServiceBaseUrlAsProperty,
+                parameterizeBackendFunctionKey:parameterizeBackendFunctionKey);
             return template.WithDirectResource(resourceType);
         }
 
@@ -425,9 +427,18 @@ namespace APIManagementTemplate.Test
         }
 
         [TestMethod]
-        public void TestServiceContainsBackendWith2DependsOn()
+        public void TestServiceContainsBackendWith1DependsOnWhenFunctionKeyIsNotParameterized()
         {
-            var backend = GetResourceFromTemplate(ResourceType.Backend, false, true);
+            var backend = GetResourceFromTemplate(ResourceType.Backend, false, true, parameterizeBackendFunctionKey: false);
+            var dependsOn = backend.DependsOn();
+
+            Assert.AreEqual(1, dependsOn.Count());
+        }
+        
+        [TestMethod]
+        public void TestServiceContainsBackendWithDependsOnWhenFunctionKeyIsParameterized()
+        {
+            var backend = GetResourceFromTemplate(ResourceType.Backend, false, true, parameterizeBackendFunctionKey: true);
             var dependsOn = backend.DependsOn();
 
             Assert.AreEqual(2, dependsOn.Count());

--- a/APIManagementTemplate/Models/DeploymentTemplate.cs
+++ b/APIManagementTemplate/Models/DeploymentTemplate.cs
@@ -592,7 +592,7 @@ namespace APIManagementTemplate.Models
                     if (code != null)
                     {
                         var value = code.Value<string>();
-                        if (value.StartsWith("{{") && value.EndsWith("}}"))
+                        if (value.StartsWith("{{") && value.EndsWith("}}") && parameterizeBackendFunctionKey)
                         {
                             var parsed = value.Substring(2, value.Length - 4);
                             dependsOn.Add($"[resourceId('Microsoft.ApiManagement/service/namedValues', parameters('{GetServiceName(servicename)}'),'{parsed}')]");


### PR DESCRIPTION
When the parameter `ParameterizeBackendFunctionKey` is false, and the x-function-key header is referencing a named value, the generated backend still `dependsOn` the named value. Since the named value is not deployed as part of the generated template it fails vaildation.