### PR TITLE
Add flag to disable extraction of backend instances

### DIFF
--- a/APIManagementTemplate/GeneratorCmdlet.cs
+++ b/APIManagementTemplate/GeneratorCmdlet.cs
@@ -50,8 +50,11 @@ namespace APIManagementTemplate
         [Parameter(Mandatory = false,HelpMessage = "Export the API operations and schemas as a swagger/Open API 2.0 definition")]
         public bool ExportSwaggerDefinition = false;
 
-        [Parameter(Mandatory = false,HelpMessage = "Export the API properties and backend used in the API policy")]
+        [Parameter(Mandatory = false,HelpMessage = "Export the API properties and backend url used in the API policy.")]
         public bool ExportApiPropertiesAndBackend = true;
+
+        [Parameter(Mandatory = false,HelpMessage = "Export the API backend instances used in the API policy. Requires ExportApiPropertiesAndBackend to be true.")]
+        public bool ExportBackendInstances = true;
 
         [Parameter(Mandatory = false,HelpMessage = "A Bearer token value")]
         public string Token = "";
@@ -112,7 +115,12 @@ namespace APIManagementTemplate
 
             try
             {
-                TemplateGenerator generator = new TemplateGenerator(APIManagement, SubscriptionId, ResourceGroup, APIFilters, ExportGroups, ExportProducts, ExportPIManagementInstance, ParametrizePropertiesOnly, resourceCollector, ReplaceSetBackendServiceBaseUrlWithProperty, FixedServiceNameParameter, CreateApplicationInsightsInstance, ApiVersion, ParameterizeBackendFunctionKey, ExportSwaggerDefinition, ExportCertificates, ExportTags, SeparatePolicyOutputFolder, ChainDependencies, ExportApiPropertiesAndBackend, FixedKeyVaultNameParameter);
+                TemplateGenerator generator = new TemplateGenerator(APIManagement, SubscriptionId, ResourceGroup,
+                    APIFilters, ExportGroups, ExportProducts, ExportPIManagementInstance, ParametrizePropertiesOnly,
+                    resourceCollector, ReplaceSetBackendServiceBaseUrlWithProperty, FixedServiceNameParameter,
+                    CreateApplicationInsightsInstance, ApiVersion, ParameterizeBackendFunctionKey,
+                    ExportSwaggerDefinition, ExportCertificates, ExportTags, SeparatePolicyOutputFolder,
+                    ChainDependencies, ExportApiPropertiesAndBackend, FixedKeyVaultNameParameter, ExportBackendInstances);
                 JObject result = generator.GenerateTemplate().Result;
                 WriteObject(result.ToString());
             }

--- a/APIManagementTemplate/TemplateGenerator.cs
+++ b/APIManagementTemplate/TemplateGenerator.cs
@@ -28,6 +28,7 @@ namespace APIManagementTemplate
         private bool replaceSetBackendServiceBaseUrlAsProperty;
         private bool fixedServiceNameParameter;
         private bool fixedKeyVaultNameParameter;
+        private readonly bool exportBackendInstances;
         private bool createApplicationInsightsInstance;
         private string apiVersion;
         private readonly bool parameterizeBackendFunctionKey;
@@ -38,7 +39,14 @@ namespace APIManagementTemplate
         private bool exportApiPropertiesAndBackend;
 
 
-        public TemplateGenerator(string servicename, string subscriptionId, string resourceGroup, string apiFilters, bool exportGroups, bool exportProducts, bool exportPIManagementInstance, bool parametrizePropertiesOnly, IResourceCollector resourceCollector, bool replaceSetBackendServiceBaseUrlAsProperty = false, bool fixedServiceNameParameter = false, bool createApplicationInsightsInstance = false, string apiVersion = null, bool parameterizeBackendFunctionKey = false, bool exportSwaggerDefinition = false, bool exportCertificates = true, bool exportTags = false, string separatePolicyOutputFolder = "", bool chainDependencies = false, bool exportApiPropertiesAndBackend = true, bool fixedKeyVaultNameParameter = false)
+        public TemplateGenerator(string servicename, string subscriptionId, string resourceGroup, string apiFilters,
+            bool exportGroups, bool exportProducts, bool exportPIManagementInstance, bool parametrizePropertiesOnly,
+            IResourceCollector resourceCollector, bool replaceSetBackendServiceBaseUrlAsProperty = false,
+            bool fixedServiceNameParameter = false, bool createApplicationInsightsInstance = false,
+            string apiVersion = null, bool parameterizeBackendFunctionKey = false, bool exportSwaggerDefinition = false,
+            bool exportCertificates = true, bool exportTags = false, string separatePolicyOutputFolder = "",
+            bool chainDependencies = false, bool exportApiPropertiesAndBackend = true,
+            bool fixedKeyVaultNameParameter = false, bool exportBackendInstances = true)
         {
             this.servicename = servicename;
             this.subscriptionId = subscriptionId;
@@ -54,6 +62,7 @@ namespace APIManagementTemplate
             this.resourceCollector = resourceCollector;
             this.fixedServiceNameParameter = fixedServiceNameParameter;
             this.fixedKeyVaultNameParameter = fixedKeyVaultNameParameter;
+            this.exportBackendInstances = exportBackendInstances;
             this.createApplicationInsightsInstance = createApplicationInsightsInstance;
             this.apiVersion = apiVersion;
             this.parameterizeBackendFunctionKey = parameterizeBackendFunctionKey;
@@ -198,7 +207,7 @@ namespace APIManagementTemplate
 
                             var backendid = TemplateHelper.GetBackendIdFromnPolicy(policyContent);
 
-                            if (!string.IsNullOrEmpty(backendid))
+                            if (!string.IsNullOrEmpty(backendid) && exportBackendInstances)
                             {
                                 BackendObject bo = await HandleBackend(template, operationSuffix, backendid);
                                 JObject backendInstance = bo?.backendInstance;
@@ -292,7 +301,7 @@ namespace APIManagementTemplate
                             apiTemplateResource.Value<JArray>("resources").Add(policyTemplateResource);
 
 
-                            if (!string.IsNullOrEmpty(backendid))
+                            if (!string.IsNullOrEmpty(backendid) && exportBackendInstances)
                             {
                                 var bo = await HandleBackend(template, apiObject.Value<string>("name"), backendid);
                                 JObject backendInstance = bo.backendInstance;


### PR DESCRIPTION
Adds a new flag (ExportBackendInstances, default true) that determines whether or not backends should be exported