### PR TITLE
Fix param null check

### DIFF
--- a/APIManagementTemplate/Models/DeploymentTemplate.cs
+++ b/APIManagementTemplate/Models/DeploymentTemplate.cs
@@ -192,7 +192,6 @@ namespace APIManagementTemplate.Models
 
         public void AddParameterFromObject(JObject obj, string propertyName, string propertyType, string paramNamePrefix = "")
         {
-
             var propValue = (string)obj[propertyName];
             if (propValue == null || (propValue.StartsWith("[") && propValue.EndsWith("]")))
                 return;

--- a/APIManagementTemplate/Models/DeploymentTemplate.cs
+++ b/APIManagementTemplate/Models/DeploymentTemplate.cs
@@ -193,7 +193,7 @@ namespace APIManagementTemplate.Models
         public void AddParameterFromObject(JObject obj, string propertyName, string propertyType, string paramNamePrefix = "")
         {
 
-            var propValue = obj[propertyName] == null ? null : obj[propertyName].ToString();
+            var propValue = (string)obj[propertyName];
             if (propValue == null || (propValue.StartsWith("[") && propValue.EndsWith("]")))
                 return;
             var defaultValue = propertyType == "secureobject" ? "" : obj[propertyName];


### PR DESCRIPTION
A recent change seems to have broken the null check for property values for parameters. When not using the service url of an API, we still get a serviceUrl parameter with a default value of null. This requires us to supply a value, even though it should just be null.

The change that broke this changed the null check of property values. In order to fully understand why this failed I tested JObject as follows:

```c#
   var jObject = JObject.Parse("{\"test\": null}");

   var jValueIsNull = jObject["test"] == null; // JValue
   var stringIsNull = (string)jObject["test"] == null; // null
   var toStringIsNull = jObject["test"].ToString() == null; // ""

   Console.WriteLine(jValueIsNull); // False
   Console.WriteLine(stringIsNull); // True
   Console.WriteLine(toStringIsNull); // False
```

To summarize, a JValue object encapsulating a null value is not null, but casting it will return null if the value is null. ToString will return an empty string.