### PR TITLE
Namedvalues are not created because not all named values are returned

### DIFF
--- a/APIManagementTemplate/TemplateGenerator.cs
+++ b/APIManagementTemplate/TemplateGenerator.cs
@@ -462,7 +462,7 @@ namespace APIManagementTemplate
                 }
             }
 
-            var properties = await resourceCollector.GetResource(GetAPIMResourceIDString() + "/namedValues", apiversion: "2020-06-01-preview");
+            var properties = await resourceCollector.GetResource(GetAPIMResourceIDString() + "/namedValues", suffix: "$top=1000", apiversion: "2020-06-01-preview");
 
             //  var properties = await resourceCollector.GetResource(GetAPIMResourceIDString() + "/properties",apiversion: "2020-06-01-preview");
             //has more?


### PR DESCRIPTION
By default, 100 named values are returned from the REST API. A quick fix is to set the maximum to 1000.