### PR TITLE
Update schema urls to existing ones. 

### DIFF
--- a/APIManagementTemplate.Test/APIManagementTemplate.Test.csproj
+++ b/APIManagementTemplate.Test/APIManagementTemplate.Test.csproj
@@ -44,6 +44,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>

--- a/APIManagementTemplate.Test/DeploymentTemplateTests.cs
+++ b/APIManagementTemplate.Test/DeploymentTemplateTests.cs
@@ -49,7 +49,7 @@ namespace APIManagementTemplate.Test
         {
             var document = Utils.GetEmbededFileContent("APIManagementTemplate.Test.Samples.VersionSet.VersionSetResource.json");
             var template = new DeploymentTemplate();
-            var actual = template.AddVersionSet(JObject.Parse(document));
+            var actual = template.AddVersionSet(JObject.Parse(document));            
             Assert.IsNotNull(actual);
         }
 
@@ -92,13 +92,13 @@ namespace APIManagementTemplate.Test
 
             var policy = (JObject)array[0];
 
-            TemplateGenerator generator = new TemplateGenerator("ibizmalo", "c107df29-a4af-4bc9-a733-f88f0eaa4296", "PreDemoTest", "", false, false, false, false, new MockResourceCollector("path"));
+            TemplateGenerator generator = new TemplateGenerator("ibizmalo", "c107df29-a4af-4bc9-a733-f88f0eaa4296", "PreDemoTest","",false,false,false,false,new MockResourceCollector("path"));
 
             var template = new DeploymentTemplate();
             template.CreatePolicy(policy);
 
-            generator.PolicyHandeAzureResources(policy, "123", template);
-            generator.PolicyHandleProperties(policy, "123", null);
+            generator.PolicyHandeAzureResources(policy,"123",template);
+            generator.PolicyHandleProperties(policy,"123",null);
 
             Assert.AreEqual(1, generator.identifiedProperties.Count);
 
@@ -109,7 +109,7 @@ namespace APIManagementTemplate.Test
         [TestMethod]
         public void RemoveBuiltInGroups()
         {
-            var document = Utils.GetEmbededFileContent("APIManagementTemplate.Test.Samples.StandardInstance-New.json");
+            var document = Utils.GetEmbededFileContent("APIManagementTemplate.Test.Samples.StandardInstance-New.json");           
             var template = DeploymentTemplate.FromString(document);
             template.RemoveResources_BuiltInGroups();
 
@@ -147,7 +147,7 @@ namespace APIManagementTemplate.Test
         [TestMethod]
         public void TestAddAPIInstance()
         {
-            var document = JObject.Parse(Utils.GetEmbededFileContent("APIManagementTemplate.Test.Samples.malo-apiminstance.json"));
+            var document = JObject.Parse( Utils.GetEmbededFileContent("APIManagementTemplate.Test.Samples.malo-apiminstance.json"));
             var template = new DeploymentTemplate();
             template.AddAPIManagementInstance(document);
             var definition = JObject.FromObject(template);
@@ -195,29 +195,29 @@ namespace APIManagementTemplate.Test
         }
 
 
-        /*  [TestMethod]
-          public void ParameterizeAuthorizationServers()
-          {
-              var document = Utils.GetEmbededFileContent("APIManagementTemplate.Test.Samples.MaloInstance-Preview-Export.json");
-              var template = DeploymentTemplate.FromString(document);
-              template.ParameterizeAuthorizationServers();
+      /*  [TestMethod]
+        public void ParameterizeAuthorizationServers()
+        {
+            var document = Utils.GetEmbededFileContent("APIManagementTemplate.Test.Samples.MaloInstance-Preview-Export.json");
+            var template = DeploymentTemplate.FromString(document);
+            template.ParameterizeAuthorizationServers();
 
-              Assert.AreEqual("http://localhost", template.parameters["authorizationServers_57e38f3e0647c00f5092b5d3_clientRegistrationEndpoint"].Value<string>("defaultValue"));
-              Assert.AreEqual("[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_clientRegistrationEndpoint')]", template.resources.Where(rr => rr.Value<string>("type") == "Microsoft.ApiManagement/service/authorizationServers" && rr.Value<string>("name") == "[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_name')]").First()["properties"].Value<string>("clientRegistrationEndpoint"));
+            Assert.AreEqual("http://localhost", template.parameters["authorizationServers_57e38f3e0647c00f5092b5d3_clientRegistrationEndpoint"].Value<string>("defaultValue"));
+            Assert.AreEqual("[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_clientRegistrationEndpoint')]", template.resources.Where(rr => rr.Value<string>("type") == "Microsoft.ApiManagement/service/authorizationServers" && rr.Value<string>("name") == "[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_name')]").First()["properties"].Value<string>("clientRegistrationEndpoint"));
 
-              Assert.AreEqual("https://adfs.mycompany.com/adfs/ls/oauth2/authorize?resource=https://mycompany.com/appid", template.parameters["authorizationServers_57e38f3e0647c00f5092b5d3_authorizationEndpoint"].Value<string>("defaultValue"));
-              Assert.AreEqual("[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_authorizationEndpoint')]", template.resources.Where(rr => rr.Value<string>("type") == "Microsoft.ApiManagement/service/authorizationServers" && rr.Value<string>("name") == "[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_name')]").First()["properties"].Value<string>("authorizationEndpoint"));
+            Assert.AreEqual("https://adfs.mycompany.com/adfs/ls/oauth2/authorize?resource=https://mycompany.com/appid", template.parameters["authorizationServers_57e38f3e0647c00f5092b5d3_authorizationEndpoint"].Value<string>("defaultValue"));
+            Assert.AreEqual("[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_authorizationEndpoint')]", template.resources.Where(rr => rr.Value<string>("type") == "Microsoft.ApiManagement/service/authorizationServers" && rr.Value<string>("name") == "[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_name')]").First()["properties"].Value<string>("authorizationEndpoint"));
 
-              Assert.AreEqual("https://adfs.mycompany.com/adfs/oauth2/token", template.parameters["authorizationServers_57e38f3e0647c00f5092b5d3_tokenEndpoint"].Value<string>("defaultValue"));
-              Assert.AreEqual("[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_tokenEndpoint')]", template.resources.Where(rr => rr.Value<string>("type") == "Microsoft.ApiManagement/service/authorizationServers" && rr.Value<string>("name") == "[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_name')]").First()["properties"].Value<string>("tokenEndpoint"));
+            Assert.AreEqual("https://adfs.mycompany.com/adfs/oauth2/token", template.parameters["authorizationServers_57e38f3e0647c00f5092b5d3_tokenEndpoint"].Value<string>("defaultValue"));
+            Assert.AreEqual("[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_tokenEndpoint')]", template.resources.Where(rr => rr.Value<string>("type") == "Microsoft.ApiManagement/service/authorizationServers" && rr.Value<string>("name") == "[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_name')]").First()["properties"].Value<string>("tokenEndpoint"));
 
-              Assert.AreEqual("mysecretpassword", template.parameters["authorizationServers_57e38f3e0647c00f5092b5d3_clientSecret"].Value<string>("defaultValue"));
-              Assert.AreEqual("[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_clientSecret')]", template.resources.Where(rr => rr.Value<string>("type") == "Microsoft.ApiManagement/service/authorizationServers" && rr.Value<string>("name") == "[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_name')]").First()["properties"].Value<string>("clientSecret"));
+            Assert.AreEqual("mysecretpassword", template.parameters["authorizationServers_57e38f3e0647c00f5092b5d3_clientSecret"].Value<string>("defaultValue"));
+            Assert.AreEqual("[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_clientSecret')]", template.resources.Where(rr => rr.Value<string>("type") == "Microsoft.ApiManagement/service/authorizationServers" && rr.Value<string>("name") == "[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_name')]").First()["properties"].Value<string>("clientSecret"));
 
-              Assert.AreEqual("123", template.parameters["authorizationServers_57e38f3e0647c00f5092b5d3_clientId"].Value<string>("defaultValue"));
-              Assert.AreEqual("[concat(resourceId('Microsoft.ApiManagement/service', parameters('service_ibizmalo_name')), [parameters('authorizationServers_57e38f3e0647c00f5092b5d3_clientId')])]", template.resources.Where(rr => rr.Value<string>("type") == "Microsoft.ApiManagement/service/authorizationServers" && rr.Value<string>("name") == "[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_name')]").First()["properties"].Value<string>("clientId"));
+            Assert.AreEqual("123", template.parameters["authorizationServers_57e38f3e0647c00f5092b5d3_clientId"].Value<string>("defaultValue"));
+            Assert.AreEqual("[concat(resourceId('Microsoft.ApiManagement/service', parameters('service_ibizmalo_name')), [parameters('authorizationServers_57e38f3e0647c00f5092b5d3_clientId')])]", template.resources.Where(rr => rr.Value<string>("type") == "Microsoft.ApiManagement/service/authorizationServers" && rr.Value<string>("name") == "[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_name')]").First()["properties"].Value<string>("clientId"));
 
-          }*/
+        }*/
 
         [TestMethod]
         public void PREVIEWFixOperationsUrlTemplateParameters()
@@ -246,7 +246,7 @@ namespace APIManagementTemplate.Test
             var dtemplate = new DeploymentTemplate();
 
             var document = JObject.Parse(Utils.GetEmbededFileContent("APIManagementTemplate.Test.Samples.UpdatedeLogicApp.service-cramoapidev-backends-LogicApp_INT3502-PricelistErrorFileToSharePoint-DEV.json"));
-            dtemplate.AddBackend(document, JObject.Parse("{\"properties\":{\"definition\": {\"triggers\": {\"manual\": {\"type\": \"Request\",\"kind\": \"Http\"}}}}}"));
+            dtemplate.AddBackend(document,JObject.Parse("{\"properties\":{\"definition\": {\"triggers\": {\"manual\": {\"type\": \"Request\",\"kind\": \"Http\"}}}}}"));
 
             Assert.AreEqual("[substring(listCallbackUrl(resourceId(parameters('LogicApp_INT3502-PricelistErrorFileToSharePoint-DEV_subscriptionId'),parameters('LogicApp_INT3502-PricelistErrorFileToSharePoint-DEV_resourceGroup'), 'Microsoft.Logic/workflows/triggers', parameters('LogicApp_INT3502-PricelistErrorFileToSharePoint-DEV_logicAppName'), 'manual'), '2017-07-01').basePath,0,add(10,indexOf(listCallbackUrl(resourceId(parameters('LogicApp_INT3502-PricelistErrorFileToSharePoint-DEV_subscriptionId'),parameters('LogicApp_INT3502-PricelistErrorFileToSharePoint-DEV_resourceGroup'), 'Microsoft.Logic/workflows/triggers', parameters('LogicApp_INT3502-PricelistErrorFileToSharePoint-DEV_logicAppName'), 'manual'), '2017-07-01').basePath,'/triggers/')))]", dtemplate.resources[0]["properties"].Value<string>("url"));
             Assert.AreEqual("[concat('https://management.azure.com/','subscriptions/',parameters('LogicApp_INT3502-PricelistErrorFileToSharePoint-DEV_subscriptionId'),'/resourceGroups/',parameters('LogicApp_INT3502-PricelistErrorFileToSharePoint-DEV_resourceGroup'),'/providers/Microsoft.Logic/workflows/',parameters('LogicApp_INT3502-PricelistErrorFileToSharePoint-DEV_logicAppName'))]", dtemplate.resources[0]["properties"].Value<string>("resourceId"));
@@ -266,7 +266,7 @@ namespace APIManagementTemplate.Test
             dtemplate.AddBackend(document, null);
             Assert.AreEqual("{}", dtemplate.parameters["Backend_CustomUrlWithoutCredentials_credentials"].Value<JObject>("defaultValue").ToString());
             Assert.AreEqual(dtemplate.resources[0]["properties"].Value<string>("credentials"), "[parameters('Backend_CustomUrlWithoutCredentials_credentials')]");
-        }
+         }
 
         [TestMethod]
         public void ScenarioTestBackendCustomURLWithCredentials()

--- a/APIManagementTemplate.Test/DeploymentTemplateTests.cs
+++ b/APIManagementTemplate.Test/DeploymentTemplateTests.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -12,6 +13,7 @@ namespace APIManagementTemplate.Test
     [TestClass]
     public class DeploymentTemplateTests
     {
+        private static readonly HttpClient _httpClient = new HttpClient();
 
         [TestMethod]
         public void TestFromString()
@@ -47,7 +49,7 @@ namespace APIManagementTemplate.Test
         {
             var document = Utils.GetEmbededFileContent("APIManagementTemplate.Test.Samples.VersionSet.VersionSetResource.json");
             var template = new DeploymentTemplate();
-            var actual = template.AddVersionSet(JObject.Parse(document));            
+            var actual = template.AddVersionSet(JObject.Parse(document));
             Assert.IsNotNull(actual);
         }
 
@@ -90,13 +92,13 @@ namespace APIManagementTemplate.Test
 
             var policy = (JObject)array[0];
 
-            TemplateGenerator generator = new TemplateGenerator("ibizmalo", "c107df29-a4af-4bc9-a733-f88f0eaa4296", "PreDemoTest","",false,false,false,false,new MockResourceCollector("path"));
+            TemplateGenerator generator = new TemplateGenerator("ibizmalo", "c107df29-a4af-4bc9-a733-f88f0eaa4296", "PreDemoTest", "", false, false, false, false, new MockResourceCollector("path"));
 
             var template = new DeploymentTemplate();
             template.CreatePolicy(policy);
 
-            generator.PolicyHandeAzureResources(policy,"123",template);
-            generator.PolicyHandleProperties(policy,"123",null);
+            generator.PolicyHandeAzureResources(policy, "123", template);
+            generator.PolicyHandleProperties(policy, "123", null);
 
             Assert.AreEqual(1, generator.identifiedProperties.Count);
 
@@ -107,7 +109,7 @@ namespace APIManagementTemplate.Test
         [TestMethod]
         public void RemoveBuiltInGroups()
         {
-            var document = Utils.GetEmbededFileContent("APIManagementTemplate.Test.Samples.StandardInstance-New.json");           
+            var document = Utils.GetEmbededFileContent("APIManagementTemplate.Test.Samples.StandardInstance-New.json");
             var template = DeploymentTemplate.FromString(document);
             template.RemoveResources_BuiltInGroups();
 
@@ -145,7 +147,7 @@ namespace APIManagementTemplate.Test
         [TestMethod]
         public void TestAddAPIInstance()
         {
-            var document = JObject.Parse( Utils.GetEmbededFileContent("APIManagementTemplate.Test.Samples.malo-apiminstance.json"));
+            var document = JObject.Parse(Utils.GetEmbededFileContent("APIManagementTemplate.Test.Samples.malo-apiminstance.json"));
             var template = new DeploymentTemplate();
             template.AddAPIManagementInstance(document);
             var definition = JObject.FromObject(template);
@@ -193,29 +195,29 @@ namespace APIManagementTemplate.Test
         }
 
 
-      /*  [TestMethod]
-        public void ParameterizeAuthorizationServers()
-        {
-            var document = Utils.GetEmbededFileContent("APIManagementTemplate.Test.Samples.MaloInstance-Preview-Export.json");
-            var template = DeploymentTemplate.FromString(document);
-            template.ParameterizeAuthorizationServers();
+        /*  [TestMethod]
+          public void ParameterizeAuthorizationServers()
+          {
+              var document = Utils.GetEmbededFileContent("APIManagementTemplate.Test.Samples.MaloInstance-Preview-Export.json");
+              var template = DeploymentTemplate.FromString(document);
+              template.ParameterizeAuthorizationServers();
 
-            Assert.AreEqual("http://localhost", template.parameters["authorizationServers_57e38f3e0647c00f5092b5d3_clientRegistrationEndpoint"].Value<string>("defaultValue"));
-            Assert.AreEqual("[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_clientRegistrationEndpoint')]", template.resources.Where(rr => rr.Value<string>("type") == "Microsoft.ApiManagement/service/authorizationServers" && rr.Value<string>("name") == "[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_name')]").First()["properties"].Value<string>("clientRegistrationEndpoint"));
+              Assert.AreEqual("http://localhost", template.parameters["authorizationServers_57e38f3e0647c00f5092b5d3_clientRegistrationEndpoint"].Value<string>("defaultValue"));
+              Assert.AreEqual("[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_clientRegistrationEndpoint')]", template.resources.Where(rr => rr.Value<string>("type") == "Microsoft.ApiManagement/service/authorizationServers" && rr.Value<string>("name") == "[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_name')]").First()["properties"].Value<string>("clientRegistrationEndpoint"));
 
-            Assert.AreEqual("https://adfs.mycompany.com/adfs/ls/oauth2/authorize?resource=https://mycompany.com/appid", template.parameters["authorizationServers_57e38f3e0647c00f5092b5d3_authorizationEndpoint"].Value<string>("defaultValue"));
-            Assert.AreEqual("[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_authorizationEndpoint')]", template.resources.Where(rr => rr.Value<string>("type") == "Microsoft.ApiManagement/service/authorizationServers" && rr.Value<string>("name") == "[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_name')]").First()["properties"].Value<string>("authorizationEndpoint"));
+              Assert.AreEqual("https://adfs.mycompany.com/adfs/ls/oauth2/authorize?resource=https://mycompany.com/appid", template.parameters["authorizationServers_57e38f3e0647c00f5092b5d3_authorizationEndpoint"].Value<string>("defaultValue"));
+              Assert.AreEqual("[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_authorizationEndpoint')]", template.resources.Where(rr => rr.Value<string>("type") == "Microsoft.ApiManagement/service/authorizationServers" && rr.Value<string>("name") == "[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_name')]").First()["properties"].Value<string>("authorizationEndpoint"));
 
-            Assert.AreEqual("https://adfs.mycompany.com/adfs/oauth2/token", template.parameters["authorizationServers_57e38f3e0647c00f5092b5d3_tokenEndpoint"].Value<string>("defaultValue"));
-            Assert.AreEqual("[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_tokenEndpoint')]", template.resources.Where(rr => rr.Value<string>("type") == "Microsoft.ApiManagement/service/authorizationServers" && rr.Value<string>("name") == "[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_name')]").First()["properties"].Value<string>("tokenEndpoint"));
+              Assert.AreEqual("https://adfs.mycompany.com/adfs/oauth2/token", template.parameters["authorizationServers_57e38f3e0647c00f5092b5d3_tokenEndpoint"].Value<string>("defaultValue"));
+              Assert.AreEqual("[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_tokenEndpoint')]", template.resources.Where(rr => rr.Value<string>("type") == "Microsoft.ApiManagement/service/authorizationServers" && rr.Value<string>("name") == "[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_name')]").First()["properties"].Value<string>("tokenEndpoint"));
 
-            Assert.AreEqual("mysecretpassword", template.parameters["authorizationServers_57e38f3e0647c00f5092b5d3_clientSecret"].Value<string>("defaultValue"));
-            Assert.AreEqual("[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_clientSecret')]", template.resources.Where(rr => rr.Value<string>("type") == "Microsoft.ApiManagement/service/authorizationServers" && rr.Value<string>("name") == "[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_name')]").First()["properties"].Value<string>("clientSecret"));
+              Assert.AreEqual("mysecretpassword", template.parameters["authorizationServers_57e38f3e0647c00f5092b5d3_clientSecret"].Value<string>("defaultValue"));
+              Assert.AreEqual("[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_clientSecret')]", template.resources.Where(rr => rr.Value<string>("type") == "Microsoft.ApiManagement/service/authorizationServers" && rr.Value<string>("name") == "[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_name')]").First()["properties"].Value<string>("clientSecret"));
 
-            Assert.AreEqual("123", template.parameters["authorizationServers_57e38f3e0647c00f5092b5d3_clientId"].Value<string>("defaultValue"));
-            Assert.AreEqual("[concat(resourceId('Microsoft.ApiManagement/service', parameters('service_ibizmalo_name')), [parameters('authorizationServers_57e38f3e0647c00f5092b5d3_clientId')])]", template.resources.Where(rr => rr.Value<string>("type") == "Microsoft.ApiManagement/service/authorizationServers" && rr.Value<string>("name") == "[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_name')]").First()["properties"].Value<string>("clientId"));
+              Assert.AreEqual("123", template.parameters["authorizationServers_57e38f3e0647c00f5092b5d3_clientId"].Value<string>("defaultValue"));
+              Assert.AreEqual("[concat(resourceId('Microsoft.ApiManagement/service', parameters('service_ibizmalo_name')), [parameters('authorizationServers_57e38f3e0647c00f5092b5d3_clientId')])]", template.resources.Where(rr => rr.Value<string>("type") == "Microsoft.ApiManagement/service/authorizationServers" && rr.Value<string>("name") == "[parameters('authorizationServers_57e38f3e0647c00f5092b5d3_name')]").First()["properties"].Value<string>("clientId"));
 
-        }*/
+          }*/
 
         [TestMethod]
         public void PREVIEWFixOperationsUrlTemplateParameters()
@@ -244,7 +246,7 @@ namespace APIManagementTemplate.Test
             var dtemplate = new DeploymentTemplate();
 
             var document = JObject.Parse(Utils.GetEmbededFileContent("APIManagementTemplate.Test.Samples.UpdatedeLogicApp.service-cramoapidev-backends-LogicApp_INT3502-PricelistErrorFileToSharePoint-DEV.json"));
-            dtemplate.AddBackend(document,JObject.Parse("{\"properties\":{\"definition\": {\"triggers\": {\"manual\": {\"type\": \"Request\",\"kind\": \"Http\"}}}}}"));
+            dtemplate.AddBackend(document, JObject.Parse("{\"properties\":{\"definition\": {\"triggers\": {\"manual\": {\"type\": \"Request\",\"kind\": \"Http\"}}}}}"));
 
             Assert.AreEqual("[substring(listCallbackUrl(resourceId(parameters('LogicApp_INT3502-PricelistErrorFileToSharePoint-DEV_subscriptionId'),parameters('LogicApp_INT3502-PricelistErrorFileToSharePoint-DEV_resourceGroup'), 'Microsoft.Logic/workflows/triggers', parameters('LogicApp_INT3502-PricelistErrorFileToSharePoint-DEV_logicAppName'), 'manual'), '2017-07-01').basePath,0,add(10,indexOf(listCallbackUrl(resourceId(parameters('LogicApp_INT3502-PricelistErrorFileToSharePoint-DEV_subscriptionId'),parameters('LogicApp_INT3502-PricelistErrorFileToSharePoint-DEV_resourceGroup'), 'Microsoft.Logic/workflows/triggers', parameters('LogicApp_INT3502-PricelistErrorFileToSharePoint-DEV_logicAppName'), 'manual'), '2017-07-01').basePath,'/triggers/')))]", dtemplate.resources[0]["properties"].Value<string>("url"));
             Assert.AreEqual("[concat('https://management.azure.com/','subscriptions/',parameters('LogicApp_INT3502-PricelistErrorFileToSharePoint-DEV_subscriptionId'),'/resourceGroups/',parameters('LogicApp_INT3502-PricelistErrorFileToSharePoint-DEV_resourceGroup'),'/providers/Microsoft.Logic/workflows/',parameters('LogicApp_INT3502-PricelistErrorFileToSharePoint-DEV_logicAppName'))]", dtemplate.resources[0]["properties"].Value<string>("resourceId"));
@@ -264,7 +266,7 @@ namespace APIManagementTemplate.Test
             dtemplate.AddBackend(document, null);
             Assert.AreEqual("{}", dtemplate.parameters["Backend_CustomUrlWithoutCredentials_credentials"].Value<JObject>("defaultValue").ToString());
             Assert.AreEqual(dtemplate.resources[0]["properties"].Value<string>("credentials"), "[parameters('Backend_CustomUrlWithoutCredentials_credentials')]");
-         }
+        }
 
         [TestMethod]
         public void ScenarioTestBackendCustomURLWithCredentials()
@@ -276,6 +278,19 @@ namespace APIManagementTemplate.Test
             dtemplate.AddBackend(document, null);
             Assert.AreEqual("{}", dtemplate.parameters["Backend_CustomUrlWithoutCredentials_credentials"].Value<JObject>("defaultValue").ToString());
             Assert.AreEqual(dtemplate.resources[0]["properties"].Value<string>("credentials"), "[parameters('Backend_CustomUrlWithoutCredentials_credentials')]");
+        }
+
+        [TestMethod]
+        public async Task TryFetchDeploymentSchemas()
+        {
+            var deploymentSchemaResponse = await _httpClient.GetAsync(Constants.deploymentSchema);
+            Assert.IsTrue(deploymentSchemaResponse.IsSuccessStatusCode);
+
+            var deploymenParameterSchemaResponse = await _httpClient.GetAsync(Constants.deploymenParameterSchema);
+            Assert.IsTrue(deploymenParameterSchemaResponse.IsSuccessStatusCode);
+
+            var parameterSchemaResponse = await _httpClient.GetAsync(Constants.parameterSchema);
+            Assert.IsTrue(parameterSchemaResponse.IsSuccessStatusCode);
         }
     }
 

--- a/APIManagementTemplate/Constants/Constants.cs
+++ b/APIManagementTemplate/Constants/Constants.cs
@@ -8,9 +8,9 @@ namespace APIManagementTemplate
 {
     public static class Constants
     {
-        internal static readonly string deploymentSchema = @"https://schema.management.azure.com/schemas/2019-08-01/deploymentTemplate.json#";
-        internal static readonly string deploymenParameterSchema = @"https://schema.management.azure.com/schemas/2019-08-01/deploymentParameters.json#";
-        internal static readonly string parameterSchema = @"https://schema.management.azure.com/schemas/2019-08-01/deploymentParameters.json#";
+        internal static readonly string deploymentSchema = @"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#";
+        internal static readonly string deploymenParameterSchema = @"https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#";
+        internal static readonly string parameterSchema = @"https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#";
 
         public static string AuthString = "https://login.microsoftonline.com/common"; //"https://login.windows.net/common/oauth2/authorize";
         public static string ClientId = "1950a258-227b-4e31-a9cf-717495945fc2";


### PR DESCRIPTION
Hi!

The $schema key in templates and parameter files created by this tool are pointing to urls that do not resolve. This causes errors in e.g. Visual Studio Code and prevents the templates from being converted to bicep.

This pull request changes the constants to the latest working versions from https://github.com/Azure/azure-resource-manager-schemas. 

It also adds a test which checks that the urls from the constants resolve properly, but feel free to ignore that if you don't want to do http requests from the tests.