### PR TITLE
Add support for policy fragments

### DIFF
--- a/APIManagementTemplate/Models/DeploymentTemplate.cs
+++ b/APIManagementTemplate/Models/DeploymentTemplate.cs
@@ -1071,6 +1071,26 @@ namespace APIManagementTemplate.Models
             return resource;
             //this.resources.Add(resource);
         }
+        public JObject CreatePolicyFragment(JObject restObject)
+        {
+            if (restObject == null)
+                return null;
+
+            var rid = new AzureResourceId(restObject.Value<string>("id"));
+            string type = restObject.Value<string>("type");
+            string name = restObject.Value<string>("name");
+            //name = $"'{name}'";
+
+            var obj = new ResourceTemplate();
+            obj.comments = "Generated for resource " + restObject.Value<string>("id");
+            obj.name = name;
+            obj.type = type;
+            var resource = JObject.FromObject(obj);
+            resource["properties"] = restObject["properties"];
+
+            return resource;
+        }
+
 
         public JObject AddApplicationInsightsInstance(JObject restObject)
         {

--- a/APIManagementTemplate/Models/DeploymentTemplate.cs
+++ b/APIManagementTemplate/Models/DeploymentTemplate.cs
@@ -1077,13 +1077,14 @@ namespace APIManagementTemplate.Models
                 return null;
 
             var rid = new AzureResourceId(restObject.Value<string>("id"));
+            string servicename = rid.ValueAfter("service");
             string type = restObject.Value<string>("type");
             string name = restObject.Value<string>("name");
             //name = $"'{name}'";
 
             var obj = new ResourceTemplate();
             obj.comments = "Generated for resource " + restObject.Value<string>("id");
-            obj.name = name;
+            obj.name = $"[concat(parameters('{AddParameter($"{GetServiceName(servicename)}", "string", servicename)}'), '/', '{name}')]";
             obj.type = type;
             var resource = JObject.FromObject(obj);
             resource["properties"] = restObject["properties"];

--- a/APIManagementTemplate/TemplateGenerator.cs
+++ b/APIManagementTemplate/TemplateGenerator.cs
@@ -211,6 +211,9 @@ namespace APIManagementTemplate
                             this.PolicyHandleProperties(pol, apiTemplateResource.Value<string>("name"),
                                 GetOperationName(operationInstance));
 
+                            this.PolicyHandlePolicyFragments(pol, apiTemplateResource.Value<string>("name"),
+                                GetOperationName(operationInstance));
+
                             var operationSuffix = apiInstance.Value<string>("name") + "_" +
                                                   operationInstance.Value<string>("name");
                             //Handle Azure Resources
@@ -318,7 +321,7 @@ namespace APIManagementTemplate
                             var policyTemplateResource = template.CreatePolicy(policy);
                             this.PolicyHandleProperties(policy, apiTemplateResource.Value<string>("name"), null);
                             apiTemplateResource.Value<JArray>("resources").Add(policyTemplateResource);
-
+                            this.PolicyHandlePolicyFragments(policy, apiTemplateResource.Value<string>("name"), null);
 
                             if (!string.IsNullOrEmpty(backendid) && exportBackendInstances)
                             {
@@ -341,6 +344,18 @@ namespace APIManagementTemplate
                             
                         }
                     }
+
+                    foreach (string policyFragmentName in identifiedFragments)
+                    {
+                        var policyFragment = await resourceCollector.GetResource(GetAPIMResourceIDString() + $"/policyFragments/{policyFragmentName}");
+                        var policyFragmentResource = template.CreatePolicyFragment(policyFragment);
+                        apiTemplateResource.Value<JArray>("resources").Add(policyFragmentResource);
+
+                        // Add the namedvalues which are used in the policy fragment
+                        var policyContent = policyFragment["properties"].Value<string>("value");
+                        HandleProperties("Global", "Global", policyContent);
+                    }
+
                     if (!exportSwaggerDefinition)
                     {
                         // Specify older apiversion, because newer versions do not return schema contents.
@@ -688,6 +703,29 @@ namespace APIManagementTemplate
             }
         }
 
+        public void PolicyHandlePolicyFragments(JObject policy, string apiname, string operationName)
+        {
+            var policyPropertyName = policy["properties"].Value<string>("policyContent") == null ? "value" : "policyContent";
+            var policyContent = policy["properties"].Value<string>(policyPropertyName);
+
+            if (policyContent == null)
+                return;
+
+            var match = Regex.Match(policyContent, "include-fragment fragment-id=\"(?<name>[-_.a-zA-Z0-9]*)\"");
+
+            while (match.Success)
+            {
+                string name = match.Groups["name"].Value;
+                var idp = identifiedFragments.FirstOrDefault(pp => pp.Equals(name));
+                if (idp == null)
+                {
+                    this.identifiedFragments.Add(name);
+                }
+                match = match.NextMatch();
+            }
+        }
+
+        public List<String> identifiedFragments = new List<String>();
         public List<Property> identifiedProperties = new List<Property>();
         public List<JObject> openidConnectProviders = null;
 

--- a/APIManagementTemplate/TemplateGenerator.cs
+++ b/APIManagementTemplate/TemplateGenerator.cs
@@ -211,14 +211,13 @@ namespace APIManagementTemplate
                             this.PolicyHandleProperties(pol, apiTemplateResource.Value<string>("name"),
                                 GetOperationName(operationInstance));
 
-                            var dependsOnArray =this.PolicyHandlePolicyFragments(pol, apiTemplateResource.Value<string>("name"),
-                                GetOperationName(operationInstance));
+                            var dependsOnArray = this.HandlePolicyFragments(pol, apiTemplateResource.Value<string>("name"), GetOperationName(operationInstance));
 
-                            if (apiTemplateResource.Value<JArray>("dependsOn") == null)
-                                apiTemplateResource["dependsOn"] = new JArray();
+                            //if (apiTemplateResource.Value<JArray>("dependsOn") == null)
+                            //    apiTemplateResource["dependsOn"] = new JArray();
 
                             // Add all fragments which are used in the policy as dependencies
-                            dependsOnArray.ToList().ForEach(f => apiTemplateResource.Value<JArray>("dependsOn").Add($"[resourceId('Microsoft.ApiManagement/service/policyFragments', parameters('{GetServiceName(servicename)}'), '{f}')]"));
+                            // dependsOnArray.ToList().ForEach(f => apiTemplateResource.Value<JArray>("dependsOn").Add($"[resourceId('Microsoft.ApiManagement/service/policyFragments', parameters('{GetServiceName(servicename)}'), '{f}')]"));
 
                             var operationSuffix = apiInstance.Value<string>("name") + "_" +
                                                   operationInstance.Value<string>("name");
@@ -324,13 +323,13 @@ namespace APIManagementTemplate
                             var policyTemplateResource = template.CreatePolicy(policy);
                             this.PolicyHandleProperties(policy, apiTemplateResource.Value<string>("name"), null);
                             apiTemplateResource.Value<JArray>("resources").Add(policyTemplateResource);
-                            var dependsOnArray = this.PolicyHandlePolicyFragments(policy, apiTemplateResource.Value<string>("name"), null);
+                            var dependsOnArray = this.HandlePolicyFragments(policy, apiTemplateResource.Value<string>("name"), null);
 
-                            if (apiTemplateResource.Value<JArray>("dependsOn") == null)
-                                apiTemplateResource["dependsOn"] = new JArray();
+                            //if (apiTemplateResource.Value<JArray>("dependsOn") == null)
+                            //    apiTemplateResource["dependsOn"] = new JArray();
 
                             // Add all fragments which are used in the policy as dependencies
-                            dependsOnArray.ToList().ForEach(f => apiTemplateResource.Value<JArray>("dependsOn").Add($"[resourceId('Microsoft.ApiManagement/service/policyFragments', parameters('{GetServiceName(servicename)}'), '{f}')]"));
+                            //dependsOnArray.ToList().ForEach(f => apiTemplateResource.Value<JArray>("dependsOn").Add($"[resourceId('Microsoft.ApiManagement/service/policyFragments', parameters('{GetServiceName(servicename)}'), '{f}')]"));
 
                             if (!string.IsNullOrEmpty(backendid) && exportBackendInstances)
                             {
@@ -710,11 +709,11 @@ namespace APIManagementTemplate
             }
         }
 
-        public JArray PolicyHandlePolicyFragments(JObject policy, string apiname, string operationName)
+        public List<String> HandlePolicyFragments(JObject policy, string apiname, string operationName)
         {
             var policyPropertyName = policy["properties"].Value<string>("policyContent") == null ? "value" : "policyContent";
             var policyContent = policy["properties"].Value<string>(policyPropertyName);
-            var dependsOnArray = new JArray();
+            var dependsOnArray = new List<String>();
 
             if (policyContent == null)
                 return dependsOnArray;
@@ -729,7 +728,7 @@ namespace APIManagementTemplate
                 {
                     this.identifiedFragments.Add(name);
                 }
-                dependsOnArray.Add($"[resourceId('Microsoft.ApiManagement/service/policyFragments', parameters('{GetServiceName(servicename)}'), '{name}')]");
+                dependsOnArray.Add(name);
                 match = match.NextMatch();
             }
 

--- a/APIManagementTemplate/TemplateGenerator.cs
+++ b/APIManagementTemplate/TemplateGenerator.cs
@@ -345,17 +345,6 @@ namespace APIManagementTemplate
                         }
                     }
 
-                    foreach (string policyFragmentName in identifiedFragments)
-                    {
-                        var policyFragment = await resourceCollector.GetResource(GetAPIMResourceIDString() + $"/policyFragments/{policyFragmentName}");
-                        var policyFragmentResource = template.CreatePolicyFragment(policyFragment);
-                        apiTemplateResource.Value<JArray>("resources").Add(policyFragmentResource);
-
-                        // Add the namedvalues which are used in the policy fragment
-                        var policyContent = policyFragment["properties"].Value<string>("value");
-                        HandleProperties("Global", "Global", policyContent);
-                    }
-
                     if (!exportSwaggerDefinition)
                     {
                         // Specify older apiversion, because newer versions do not return schema contents.
@@ -401,6 +390,18 @@ namespace APIManagementTemplate
                     }
 
                 }
+            }
+
+            foreach (string policyFragmentName in identifiedFragments)
+            {
+                var policyFragment = await resourceCollector.GetResource(GetAPIMResourceIDString() + $"/policyFragments/{policyFragmentName}");
+                var policyFragmentResource = template.CreatePolicyFragment(policyFragment);
+                var apim = await resourceCollector.GetResource(GetAPIMResourceIDString());
+                apim.Add(policyFragmentResource);
+
+                // Add the namedvalues which are used in the policy fragment
+                var policyContent = policyFragment["properties"].Value<string>("value");
+                HandleProperties("Global", "Global", policyContent);
             }
 
             // Export all groups if we don't export the products.
@@ -711,7 +712,7 @@ namespace APIManagementTemplate
             if (policyContent == null)
                 return;
 
-            var match = Regex.Match(policyContent, "include-fragment fragment-id=\"(?<name>[-_.a-zA-Z0-9]*)\"");
+            var match = Regex.Match(policyContent, "fragment-id=\"(?<name>[-_.a-zA-Z0-9]*)\"");
 
             while (match.Success)
             {

--- a/APIManagementTemplate/TemplateGenerator.cs
+++ b/APIManagementTemplate/TemplateGenerator.cs
@@ -211,8 +211,14 @@ namespace APIManagementTemplate
                             this.PolicyHandleProperties(pol, apiTemplateResource.Value<string>("name"),
                                 GetOperationName(operationInstance));
 
-                            this.PolicyHandlePolicyFragments(pol, apiTemplateResource.Value<string>("name"),
+                            var dependsOnArray =this.PolicyHandlePolicyFragments(pol, apiTemplateResource.Value<string>("name"),
                                 GetOperationName(operationInstance));
+
+                            if (apiTemplateResource.Value<JArray>("dependsOn") == null)
+                                apiTemplateResource["dependsOn"] = new JArray();
+
+                            // Add all fragments which are used in the policy as dependencies
+                            dependsOnArray.ToList().ForEach(f => apiTemplateResource.Value<JArray>("dependsOn").Add($"[resourceId('Microsoft.ApiManagement/service/policyFragments', parameters('{GetServiceName(servicename)}'), '{f}')]"));
 
                             var operationSuffix = apiInstance.Value<string>("name") + "_" +
                                                   operationInstance.Value<string>("name");
@@ -234,9 +240,6 @@ namespace APIManagementTemplate
                                 JObject backendInstance = bo?.backendInstance;
                                 if (backendInstance != null)
                                 {
-                                    if (apiTemplateResource.Value<JArray>("dependsOn") == null)
-                                        apiTemplateResource["dependsOn"] = new JArray();
-
                                     //add dependeOn
                                     apiTemplateResource.Value<JArray>("dependsOn").Add(
                                         $"[resourceId('Microsoft.ApiManagement/service/backends', parameters('{GetServiceName(servicename)}'), '{backendInstance.Value<string>("name")}')]");
@@ -321,7 +324,13 @@ namespace APIManagementTemplate
                             var policyTemplateResource = template.CreatePolicy(policy);
                             this.PolicyHandleProperties(policy, apiTemplateResource.Value<string>("name"), null);
                             apiTemplateResource.Value<JArray>("resources").Add(policyTemplateResource);
-                            this.PolicyHandlePolicyFragments(policy, apiTemplateResource.Value<string>("name"), null);
+                            var dependsOnArray = this.PolicyHandlePolicyFragments(policy, apiTemplateResource.Value<string>("name"), null);
+
+                            if (apiTemplateResource.Value<JArray>("dependsOn") == null)
+                                apiTemplateResource["dependsOn"] = new JArray();
+
+                            // Add all fragments which are used in the policy as dependencies
+                            dependsOnArray.ToList().ForEach(f => apiTemplateResource.Value<JArray>("dependsOn").Add($"[resourceId('Microsoft.ApiManagement/service/policyFragments', parameters('{GetServiceName(servicename)}'), '{f}')]"));
 
                             if (!string.IsNullOrEmpty(backendid) && exportBackendInstances)
                             {
@@ -329,9 +338,6 @@ namespace APIManagementTemplate
                                 JObject backendInstance = bo.backendInstance;
                                 if (backendInstance != null)
                                 {
-                                    if (apiTemplateResource.Value<JArray>("dependsOn") == null)
-                                        apiTemplateResource["dependsOn"] = new JArray();
-
                                     //add dependeOn
                                     apiTemplateResource.Value<JArray>("dependsOn").Add($"[resourceId('Microsoft.ApiManagement/service/backends', parameters('{GetServiceName(servicename)}'), '{backendInstance.Value<string>("name")}')]");
                                 }
@@ -704,13 +710,14 @@ namespace APIManagementTemplate
             }
         }
 
-        public void PolicyHandlePolicyFragments(JObject policy, string apiname, string operationName)
+        public JArray PolicyHandlePolicyFragments(JObject policy, string apiname, string operationName)
         {
             var policyPropertyName = policy["properties"].Value<string>("policyContent") == null ? "value" : "policyContent";
             var policyContent = policy["properties"].Value<string>(policyPropertyName);
+            var dependsOnArray = new JArray();
 
             if (policyContent == null)
-                return;
+                return dependsOnArray;
 
             var match = Regex.Match(policyContent, "fragment-id=\"(?<name>[-_.a-zA-Z0-9]*)\"");
 
@@ -722,8 +729,11 @@ namespace APIManagementTemplate
                 {
                     this.identifiedFragments.Add(name);
                 }
+                dependsOnArray.Add($"[resourceId('Microsoft.ApiManagement/service/policyFragments', parameters('{GetServiceName(servicename)}'), '{name}')]");
                 match = match.NextMatch();
             }
+
+            return dependsOnArray;
         }
 
         public List<String> identifiedFragments = new List<String>();

--- a/APIManagementTemplate/TemplateGenerator.cs
+++ b/APIManagementTemplate/TemplateGenerator.cs
@@ -213,11 +213,11 @@ namespace APIManagementTemplate
 
                             var dependsOnArray = this.HandlePolicyFragments(pol, apiTemplateResource.Value<string>("name"), GetOperationName(operationInstance));
 
-                            //if (apiTemplateResource.Value<JArray>("dependsOn") == null)
-                            //    apiTemplateResource["dependsOn"] = new JArray();
+                            if (apiTemplateResource.Value<JArray>("dependsOn") == null)
+                                apiTemplateResource["dependsOn"] = new JArray();
 
                             // Add all fragments which are used in the policy as dependencies
-                            // dependsOnArray.ToList().ForEach(f => apiTemplateResource.Value<JArray>("dependsOn").Add($"[resourceId('Microsoft.ApiManagement/service/policyFragments', parameters('{GetServiceName(servicename)}'), '{f}')]"));
+                            dependsOnArray.ToList().ForEach(f => apiTemplateResource.Value<JArray>("dependsOn").Add($"[resourceId('Microsoft.ApiManagement/service/policyFragments', parameters('{GetServiceName(servicename)}'), '{f}')]"));
 
                             var operationSuffix = apiInstance.Value<string>("name") + "_" +
                                                   operationInstance.Value<string>("name");
@@ -325,11 +325,11 @@ namespace APIManagementTemplate
                             apiTemplateResource.Value<JArray>("resources").Add(policyTemplateResource);
                             var dependsOnArray = this.HandlePolicyFragments(policy, apiTemplateResource.Value<string>("name"), null);
 
-                            //if (apiTemplateResource.Value<JArray>("dependsOn") == null)
-                            //    apiTemplateResource["dependsOn"] = new JArray();
+                            if (apiTemplateResource.Value<JArray>("dependsOn") == null)
+                                apiTemplateResource["dependsOn"] = new JArray();
 
                             // Add all fragments which are used in the policy as dependencies
-                            //dependsOnArray.ToList().ForEach(f => apiTemplateResource.Value<JArray>("dependsOn").Add($"[resourceId('Microsoft.ApiManagement/service/policyFragments', parameters('{GetServiceName(servicename)}'), '{f}')]"));
+                            dependsOnArray.ToList().ForEach(f => apiTemplateResource.Value<JArray>("dependsOn").Add($"[resourceId('Microsoft.ApiManagement/service/policyFragments', parameters('{GetServiceName(servicename)}'), '{f}')]"));
 
                             if (!string.IsNullOrEmpty(backendid) && exportBackendInstances)
                             {
@@ -401,8 +401,24 @@ namespace APIManagementTemplate
             {
                 var policyFragment = await resourceCollector.GetResource(GetAPIMResourceIDString() + $"/policyFragments/{policyFragmentName}");
                 var policyFragmentResource = template.CreatePolicyFragment(policyFragment);
-                var apim = await resourceCollector.GetResource(GetAPIMResourceIDString());
-                apim.Add(policyFragmentResource);
+
+                // Add the policy fragment to the template resources
+                if (exportPIManagementInstance)
+                {
+                    // Find the APIM template resource and add the fragment to its resources array
+                    var apimTemplateResource = template.resources.FirstOrDefault(r =>
+                        r.Value<string>("type") == "Microsoft.ApiManagement/service");
+
+                    if (apimTemplateResource != null && apimTemplateResource["resources"] != null)
+                    {
+                        apimTemplateResource.Value<JArray>("resources").Add(policyFragmentResource);
+                    }
+                }
+                else
+                {
+                    // If not exporting APIM instance, add as top-level resource
+                    template.resources.Add(policyFragmentResource);
+                }
 
                 // Add the namedvalues which are used in the policy fragment
                 var policyContent = policyFragment["properties"].Value<string>("value");

--- a/APIManagementTemplate/TemplateGenerator.cs
+++ b/APIManagementTemplate/TemplateGenerator.cs
@@ -397,34 +397,6 @@ namespace APIManagementTemplate
                 }
             }
 
-            foreach (string policyFragmentName in identifiedFragments)
-            {
-                var policyFragment = await resourceCollector.GetResource(GetAPIMResourceIDString() + $"/policyFragments/{policyFragmentName}");
-                var policyFragmentResource = template.CreatePolicyFragment(policyFragment);
-
-                // Add the policy fragment to the template resources
-                if (exportPIManagementInstance)
-                {
-                    // Find the APIM template resource and add the fragment to its resources array
-                    var apimTemplateResource = template.resources.FirstOrDefault(r =>
-                        r.Value<string>("type") == "Microsoft.ApiManagement/service");
-
-                    if (apimTemplateResource != null && apimTemplateResource["resources"] != null)
-                    {
-                        apimTemplateResource.Value<JArray>("resources").Add(policyFragmentResource);
-                    }
-                }
-                else
-                {
-                    // If not exporting APIM instance, add as top-level resource
-                    template.resources.Add(policyFragmentResource);
-                }
-
-                // Add the namedvalues which are used in the policy fragment
-                var policyContent = policyFragment["properties"].Value<string>("value");
-                HandleProperties("Global", "Global", policyContent);
-            }
-
             // Export all groups if we don't export the products.
             if (exportGroups && !exportProducts)
             {
@@ -503,10 +475,44 @@ namespace APIManagementTemplate
                             }
 
                             productTemplateResource.Value<JArray>("resources").Add(pol);
+
                             this.PolicyHandleProperties(policy, productTemplateResource.Value<string>("name"), null);
+
+                            var dependsOnArray = this.HandlePolicyFragments(pol, productTemplateResource.Value<string>("name"), null);
+
+                            // Add all fragments which are used in the policy as dependencies
+                            dependsOnArray.ToList().ForEach(f => productTemplateResource.Value<JArray>("dependsOn").Add($"[resourceId('Microsoft.ApiManagement/service/policyFragments', parameters('{GetServiceName(servicename)}'), '{f}')]"));
                         }
                     }
                 }
+            }
+
+            foreach (string policyFragmentName in identifiedFragments)
+            {
+                var policyFragment = await resourceCollector.GetResource(GetAPIMResourceIDString() + $"/policyFragments/{policyFragmentName}");
+                var policyFragmentResource = template.CreatePolicyFragment(policyFragment);
+
+                // Add the policy fragment to the template resources
+                if (exportPIManagementInstance)
+                {
+                    // Find the APIM template resource and add the fragment to its resources array
+                    var apimTemplateResource = template.resources.FirstOrDefault(r =>
+                        r.Value<string>("type") == "Microsoft.ApiManagement/service");
+
+                    if (apimTemplateResource != null && apimTemplateResource["resources"] != null)
+                    {
+                        apimTemplateResource.Value<JArray>("resources").Add(policyFragmentResource);
+                    }
+                }
+                else
+                {
+                    // If not exporting APIM instance, add as top-level resource
+                    template.resources.Add(policyFragmentResource);
+                }
+
+                // Add the namedvalues which are used in the policy fragment
+                var policyContent = policyFragment["properties"].Value<string>("value");
+                HandleProperties("Global", "Global", policyContent);
             }
 
             var properties = await resourceCollector.GetResource(GetAPIMResourceIDString() + "/namedValues", suffix: "$top=1000");


### PR DESCRIPTION
Policy fragments can be used in api policies, operation policies and product policies.

With this change, the policy fragments are included in the generated template. When properties c.q. namedvalues are used in the policy fragment, they are also included in the template.

Related to issue #142 